### PR TITLE
fix: deduplicate ERC20 batch approvals

### DIFF
--- a/src/sdk/assets.ts
+++ b/src/sdk/assets.ts
@@ -416,6 +416,12 @@ export class AssetsManager {
             callData,
           })
         } else if (asset.tokenStandard === TokenStandard.ERC20) {
+          const contractAddress = asset.tokenAddress.toLowerCase()
+          if (processedContracts.has(contractAddress)) {
+            continue
+          }
+          processedContracts.add(contractAddress)
+
           // approve(spender, amount) - use max uint256 for unlimited
           const callData = cc.encodeFunctionData({
             abi: APPROVE_ABI,

--- a/test/sdk/batchApproveAssets.spec.ts
+++ b/test/sdk/batchApproveAssets.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test, vi } from "vitest"
+import { AssetsManager } from "../../src/sdk/assets"
+import { Chain, EventType, TokenStandard } from "../../src/types"
+
+describe("AssetsManager: batchApproveAssets", () => {
+  test("deduplicates approvals for the same ERC20 contract case-insensitively", async () => {
+    const tokenAddress = "0x0f5d2fb29fb7d3cfee444a200298f468908cc942"
+    const fromAddress = "0x0000000000000000000000000000000000000001"
+
+    const readContract = vi.fn().mockResolvedValue(0n)
+    const encodeFunctionData = vi.fn().mockReturnValue("0xapproval")
+    const writeContract = vi.fn().mockResolvedValue({
+      hash: "0xtest",
+      wait: async () => {},
+    })
+    const sendTransaction = vi.fn().mockResolvedValue({
+      hash: "0xtest",
+      wait: async () => {},
+    })
+    const confirmTransaction = vi.fn().mockResolvedValue(undefined)
+
+    const manager = new AssetsManager({
+      chain: Chain.Mainnet,
+      wallet: {
+        signer: {
+          getAddress: async () => fromAddress,
+          sendTransaction,
+          signTypedData: async () => "0xsignature",
+        },
+        provider: {
+          waitForTransaction: async () => {},
+        },
+      },
+      contractCaller: {
+        readContract,
+        writeContract,
+        encodeFunctionData,
+      },
+      api: {} as any,
+      seaport: {} as any,
+      logger: vi.fn(),
+      dispatch: vi.fn(),
+      confirmTransaction,
+      requireAccountIsAvailable: vi.fn().mockResolvedValue(undefined),
+    })
+
+    await manager.batchApproveAssets({
+      assets: [
+        {
+          asset: {
+            tokenAddress,
+            tokenId: null,
+            tokenStandard: TokenStandard.ERC20,
+          },
+          amount: "1",
+        },
+        {
+          asset: {
+            tokenAddress: tokenAddress.toUpperCase(),
+            tokenId: null,
+            tokenStandard: TokenStandard.ERC20,
+          },
+          amount: "2",
+        },
+      ],
+      fromAddress,
+    })
+
+    expect(sendTransaction).toHaveBeenCalledTimes(1)
+    expect(writeContract).not.toHaveBeenCalled()
+    expect(encodeFunctionData).toHaveBeenCalledTimes(1)
+    expect(confirmTransaction).toHaveBeenCalledWith(
+      "0xtest",
+      EventType.ApproveAllAssets,
+      "Approving asset for transfer",
+    )
+  })
+})


### PR DESCRIPTION
## Thanks for opening a PR!

We really appreciate you taking the time to contribute. It means a lot to the OpenSea team and the broader developer community.

### A quick note about how this repo works

This repository is a **read-only mirror** of a package maintained in an internal monorepo. Because of that, pull requests cannot be merged directly here.

**But don't worry -- your contribution won't be lost!** Here's what happens next:

1. Our team reviews every PR that comes in.
2. If the change looks good, we'll recreate it internally in our monorepo.
3. The fix will be synced back to this public repo on the next release.

We'll keep you posted on the PR as things progress.

### Is this a bug report?

If you're reporting a bug rather than submitting a code fix, opening an **issue** is usually the fastest path to a resolution. Bug report issues help us triage and prioritize effectively.

Thanks again for helping make OpenSea better for everyone!

---

## Summary

Deduplicates ERC20 approvals in `batchApproveAssets` when the same token contract appears multiple times, including addresses that differ only by casing.

## Root cause

`batchApproveAssets` already tracks processed contract addresses for NFT approvals, but the ERC20 branch did not use that set. Duplicate entries could therefore generate multiple identical `approve(conduit, MAX_UINT256)` calls and unnecessarily take the multicall path.

## Changes

- Normalize ERC20 contract addresses to lowercase before deduplication.
- Reuse `processedContracts` so only one unlimited approval is generated per ERC20 contract.
- Add a deterministic regression test covering duplicate ERC20 entries with different address casing.

## Validation

- Regression test reproduced the duplicate-approval behavior before the fix and passes after it.
- Targeted tests: 11/11 passed.
- Full unit suite: 928/928 passed across 41 test files.
- Biome check passes for the two changed files.
