### PR TITLE
fix(viem): omit missing typed-data chainId

### DIFF
--- a/src/provider/viem-adapter.ts
+++ b/src/provider/viem-adapter.ts
@@ -89,7 +89,7 @@ function createViemSigner(
       }
       return walletClient.signTypedData({
         domain: {
-          chainId: Number(domain.chainId),
+          chainId: domain.chainId != null ? Number(domain.chainId) : undefined,
           name: domain.name,
           version: domain.version,
           verifyingContract: domain.verifyingContract as `0x${string}`,

--- a/test/provider/viem-adapter.spec.ts
+++ b/test/provider/viem-adapter.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest"
+import { createViemWallet } from "../../src/provider/viem-adapter"
+
+describe("createViemWallet", () => {
+  it("does not pass NaN when typed-data domain omits chainId", async () => {
+    const signTypedData = vi.fn().mockResolvedValue("0xsignature")
+    const wallet = createViemWallet({
+      publicClient: {
+        waitForTransactionReceipt: vi.fn(),
+      } as any,
+      walletClient: {
+        account: {
+          address: "0x0000000000000000000000000000000000000001",
+        },
+        signTypedData,
+      } as any,
+    })
+
+    if (!("signer" in wallet)) {
+      throw new Error("expected wallet signer")
+    }
+
+    await wallet.signer.signTypedData(
+      {
+        name: "OpenSea",
+        version: "1",
+        verifyingContract: "0x0000000000000000000000000000000000000002",
+      } as any,
+      {
+        Test: [{ name: "value", type: "string" }],
+      },
+      { value: "hello" },
+    )
+
+    const call = signTypedData.mock.calls[0][0]
+    expect(call.domain.chainId).toBeUndefined()
+    expect(Number.isNaN(call.domain.chainId)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- avoid converting a missing typed-data `domain.chainId` into `NaN` in the viem signer adapter
- pass `undefined` when `chainId` is absent, matching the optional handling used by the viem seaport bridge
- add a regression test for signing typed data with no `chainId` in the domain

Fixes #1994.

## Testing
- `npm run test -- test/provider/viem-adapter.spec.ts`
- `npm run check-types`
- `npx biome check src/provider/viem-adapter.ts test/provider/viem-adapter.spec.ts`

Additional local notes:
- `npm ci` currently fails because `package.json` and `package-lock.json` are out of sync on `main` (`eslint@10.8.1` and transitive deps missing from the lockfile). I used `npm install --package-lock=false` for local verification without changing the lockfile.
- `npm run test` reports 39 passed test files / 858 passed tests, then exits non-zero due to two unhandled `ERR_REQUIRE_ESM` errors from `@asamuzakjp/css-color` requiring `@csstools/css-calc` under the local Node v21.6.1 environment. The targeted viem adapter test passes.
- `npm run lint` reports existing repository-wide CRLF formatting differences; the two changed files pass `npx biome check` directly.