### PR TITLE
fix: read basic-order ERC20 preflight from API parameters

### DIFF
--- a/src/orders/erc20Fulfillment.ts
+++ b/src/orders/erc20Fulfillment.ts
@@ -171,7 +171,13 @@ export function getErc20Payment(inputData: unknown): Erc20Payment | null {
     return null
   }
 
-  if ("basicOrderParameters" in inputData) {
+  // The fulfillment API serializes a decoded fulfillBasicOrder call as a single
+  // `parameters` struct. Older hand-written SDK types called this
+  // `basicOrderParameters`, so accept that shape as a compatibility fallback.
+  if (isRecord(inputData.parameters)) {
+    return basicOrderErc20Payment(inputData.parameters)
+  }
+  if (isRecord(inputData.basicOrderParameters)) {
     return basicOrderErc20Payment(inputData.basicOrderParameters)
   }
 
@@ -200,8 +206,13 @@ export function getFulfillerConduitKey(inputData: unknown): string | null {
   if (typeof direct === "string") {
     return direct
   }
-  if (isRecord(inputData.basicOrderParameters)) {
-    const fromBasicOrder = inputData.basicOrderParameters.fulfillerConduitKey
+  const basicOrderParameters = isRecord(inputData.parameters)
+    ? inputData.parameters
+    : isRecord(inputData.basicOrderParameters)
+      ? inputData.basicOrderParameters
+      : null
+  if (basicOrderParameters) {
+    const fromBasicOrder = basicOrderParameters.fulfillerConduitKey
     if (typeof fromBasicOrder === "string") {
       return fromBasicOrder
     }

--- a/test/orders/erc20Fulfillment.spec.ts
+++ b/test/orders/erc20Fulfillment.spec.ts
@@ -69,7 +69,9 @@ function advancedOrderInput(consideration: unknown[]) {
 /** basicOrderType 8 is route 2, ERC20_TO_ERC721: the fulfiller pays with ERC20. */
 function basicOrderInput(overrides: Record<string, unknown> = {}) {
   return {
-    basicOrderParameters: {
+    // The fulfillment API serializes fulfillBasicOrder's single decoded struct
+    // under `parameters`, matching the shape consumed by FulfillmentManager.
+    parameters: {
       considerationToken: USDG,
       considerationIdentifier: "0",
       considerationAmount: "360000000",
@@ -170,7 +172,7 @@ describe("getErc20Payment: advanced and standard orders", () => {
 })
 
 describe("getErc20Payment: basic orders", () => {
-  test("sums considerationAmount and additionalRecipients for an ERC20 route", () => {
+  test("sums considerationAmount and additionalRecipients from the API parameters shape", () => {
     expect(getErc20Payment(basicOrderInput())).toEqual({
       token: USDG,
       amount: 369000000n,
@@ -252,7 +254,7 @@ describe("getFulfillerConduitKey", () => {
     expect(getFulfillerConduitKey(advancedOrderInput([]))).toBe(CONDUIT_KEY)
   })
 
-  test("reads the key nested in basicOrderParameters", () => {
+  test("reads the key nested in the basic-order API parameters", () => {
     expect(getFulfillerConduitKey(basicOrderInput())).toBe(CONDUIT_KEY)
   })
 


### PR DESCRIPTION
## Thanks for opening a PR!

We really appreciate you taking the time to contribute. It means a lot to the OpenSea team and the broader developer community.

### A quick note about how this repo works

This repository is a **read-only mirror** of a package maintained in an internal monorepo. Because of that, pull requests cannot be merged directly here.

**But don't worry -- your contribution won't be lost!** Here's what happens next:

1. Our team reviews every PR that comes in.
2. If the change looks good, we'll recreate it internally in our monorepo.
3. The fix will be synced back to this public repo on the next release.

We'll keep you posted on the PR as things progress.

### Is this a bug report?

If you're reporting a bug rather than submitting a code fix, opening an **issue** is usually the fastest path to a resolution. Bug report issues help us triage and prioritize effectively.

Thanks again for helping make OpenSea better for everyone!

## Summary

Fixes ERC20 fulfillment preflight for basic-order responses by reading the API's actual `inputData.parameters` shape.

## Root cause

The fulfillment API returns basic-order data under `inputData.parameters`, but `getErc20Payment()` and `getFulfillerConduitKey()` were still looking for `basicOrderParameters`.

As a result, ERC20 basic listings could skip the payment/allowance preflight because the helper returned no payment data. The existing unit fixture used the same stale field name, so it did not cover the production wire shape.

## Changes

- Read basic-order payment data from `inputData.parameters`.
- Read the basic-order fulfiller conduit key from `inputData.parameters`.
- Keep `basicOrderParameters` as a compatibility fallback.
- Update the regression fixture to match the API wire shape.

## Validation

- `test/orders/erc20Fulfillment.spec.ts`: 30/30 passed.
- Full unit suite: 945/945 passed across 41 test files.
- Targeted Biome check passes for the changed files.