### PR TITLE
fix: infer EIP-712 primaryType in viem bridge

### DIFF
--- a/src/provider/seaport-bridge.ts
+++ b/src/provider/seaport-bridge.ts
@@ -51,6 +51,25 @@ export function createSeaportBridge(
   return new ViemEthersSigner(walletClient, ethersProvider)
 }
 
+/** Infer the EIP-712 root struct: the named type no other struct references. */
+function inferPrimaryType(types: Record<string, Array<{ type: string }>>): string {
+  const namedTypes = Object.keys(types).filter(key => key !== "EIP712Domain")
+  const referencedTypes = new Set<string>()
+
+  for (const fields of Object.values(types)) {
+    for (const field of fields) {
+      // Strip any array suffix before checking whether this field references a
+      // named struct (e.g. Person[] -> Person).
+      const referencedType = field.type.replace(/\[[^\]]*\]$/g, "")
+      if (namedTypes.includes(referencedType)) {
+        referencedTypes.add(referencedType)
+      }
+    }
+  }
+
+  return namedTypes.find(type => !referencedTypes.has(type)) ?? namedTypes[0] ?? ""
+}
+
 /**
  * Minimal ethers AbstractSigner implementation backed by a viem WalletClient.
  * Implements the methods that seaport-js calls: getAddress, sendTransaction,
@@ -145,9 +164,7 @@ class ViemEthersSigner extends AbstractSigner {
   }
 
   async signTypedData(domain: any, types: any, value: any): Promise<string> {
-    const primaryType =
-      Object.keys(types).find(key => key !== "EIP712Domain") ||
-      Object.keys(types)[0]
+    const primaryType = inferPrimaryType(types)
 
     return this._walletClient.signTypedData({
       domain: {

--- a/test/provider/seaport-bridge.spec.ts
+++ b/test/provider/seaport-bridge.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from "vitest"
+import { createSeaportBridge } from "../../src/provider/seaport-bridge"
+
+describe("createSeaportBridge", () => {
+  test("infers the EIP-712 root primaryType instead of using the first type key", async () => {
+    const signTypedData = vi.fn().mockResolvedValue("0xsignature")
+    const walletClient = {
+      account: {
+        address: "0x0000000000000000000000000000000000000001",
+      },
+      chain: { id: 1 },
+      signTypedData,
+    }
+    const publicClient = {
+      transport: { url: "http://127.0.0.1:8545" },
+    }
+
+    const signer = createSeaportBridge({
+      publicClient,
+      walletClient,
+    } as any)
+
+    const types = {
+      Person: [
+        { name: "name", type: "string" },
+        { name: "wallet", type: "address" },
+      ],
+      Mail: [
+        { name: "from", type: "Person" },
+        { name: "to", type: "Person" },
+        { name: "contents", type: "string" },
+      ],
+    }
+
+    await (signer as any).signTypedData(
+      { name: "Ether Mail", version: "1", chainId: 1 },
+      types,
+      {
+        from: {
+          name: "Cow",
+          wallet: "0x0000000000000000000000000000000000000002",
+        },
+        to: {
+          name: "Bob",
+          wallet: "0x0000000000000000000000000000000000000003",
+        },
+        contents: "Hello, Bob!",
+      },
+    )
+
+    expect(signTypedData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primaryType: "Mail",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Thanks for opening a PR!

We really appreciate you taking the time to contribute. It means a lot to the OpenSea team and the broader developer community.

### A quick note about how this repo works

This repository is a **read-only mirror** of a package maintained in an internal monorepo. Because of that, pull requests cannot be merged directly here.

**But don't worry -- your contribution won't be lost!** Here's what happens next:

1. Our team reviews every PR that comes in.
2. If the change looks good, we'll recreate it internally in our monorepo.
3. The fix will be synced back to this public repo on the next release.

We'll keep you posted on the PR as things progress.

### Is this a bug report?

If you're reporting a bug rather than submitting a code fix, opening an **issue** is usually the fastest path to a resolution. Bug report issues help us triage and prioritize effectively.

Thanks again for helping make OpenSea better for everyone!


## Summary

Fixes EIP-712 signing through the viem Seaport bridge when a dependency struct appears before the actual root struct in the `types` object.

## Root cause

`ViemEthersSigner.signTypedData()` selected the first non-`EIP712Domain` key as `primaryType`.

EIP-712 does not require the root struct to be declared first. For example, when `Person` is declared before `Mail` and `Mail` references `Person`, the root type is `Mail`, but the bridge selected `Person`.

This could cause viem-backed signing to use the wrong typed-data primary type.

## Changes

- Infer the root EIP-712 struct by finding the named type that is not referenced by another struct.
- Handle struct references through array types such as `Person[]`.
- Preserve the existing first-type fallback for cyclic or ambiguous type graphs.
- Add a regression test with a dependency struct declared before the root struct.

## Validation

- Regression test fails before the fix because `Person` is selected instead of `Mail`.
- Targeted regression test: 1/1 passed after the fix.
- Full unit suite: 946/946 passed across 42 test files.
- Targeted Biome check passes for the changed files after formatting.