### PR TITLE
fix: normalize protocol addresses in cancelOrders batches

### DIFF
--- a/src/sdk/cancellation.ts
+++ b/src/sdk/cancellation.ts
@@ -3,6 +3,7 @@ import type { Listing, Offer } from "../api/types"
 import type { OrderV2 } from "../orders/types"
 import { DEFAULT_SEAPORT_CONTRACT_ADDRESS } from "../orders/utils"
 import { type Chain, EventType } from "../types"
+import { checksumAddress } from "../utils/address"
 import {
   getChainId,
   getSeaportInstance,
@@ -179,7 +180,7 @@ export class CancellationManager {
 
     const addProtocolAddress = (value: string) => {
       requireValidProtocol(value)
-      protocolAddresses.add(value)
+      protocolAddresses.add(checksumAddress(value))
     }
 
     if (orders) {

--- a/test/sdk/cancelOrdersProtocolCasing.spec.ts
+++ b/test/sdk/cancelOrdersProtocolCasing.spec.ts
@@ -1,0 +1,55 @@
+import { CROSS_CHAIN_SEAPORT_V1_6_ADDRESS } from "@opensea/seaport-js/lib/constants"
+import type { OrderV2 } from "../../src/orders/types"
+import { CancellationManager } from "../../src/sdk/cancellation"
+import { createMockContext } from "../fixtures/context"
+import { describe, expect, test, vi } from "vitest"
+
+const orderWithProtocol = (protocolAddress: string): OrderV2 =>
+  ({
+    orderHash: "0x123",
+    chain: "ethereum",
+    type: "basic",
+    protocolAddress,
+    protocolData: {
+      parameters: {
+        offerer: "0x0000000000000000000000000000000000000001",
+        zone: "0x0000000000000000000000000000000000000000",
+        offer: [],
+        consideration: [],
+        orderType: 0,
+        startTime: "0",
+        endTime: "0",
+        zoneHash: `0x${"00".repeat(32)}`,
+        salt: "0",
+        conduitKey: `0x${"00".repeat(32)}`,
+        totalOriginalConsiderationItems: 0,
+        counter: 0,
+      },
+      signature: "0x",
+    },
+  }) as unknown as OrderV2
+
+describe("CancellationManager protocol address casing", () => {
+  test("treats differently-cased forms of the same protocol address as one protocol", async () => {
+    const accountCheck = new Error("account check reached")
+    const requireAccountIsAvailable = vi.fn().mockRejectedValue(accountCheck)
+    const manager = new CancellationManager(
+      createMockContext({ requireAccountIsAvailable }),
+    )
+
+    const upperCaseProtocol =
+      `0x${CROSS_CHAIN_SEAPORT_V1_6_ADDRESS.slice(2).toUpperCase()}`
+
+    await expect(
+      manager.cancelOrders({
+        orders: [
+          orderWithProtocol(CROSS_CHAIN_SEAPORT_V1_6_ADDRESS),
+          orderWithProtocol(upperCaseProtocol),
+        ],
+        accountAddress: "0x0000000000000000000000000000000000000001",
+      }),
+    ).rejects.toThrow(accountCheck)
+
+    expect(requireAccountIsAvailable).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Thanks for opening a PR!

We really appreciate you taking the time to contribute. It means a lot to the OpenSea team and the broader developer community.

### A quick note about how this repo works

This repository is a **read-only mirror** of a package maintained in an internal monorepo. Because of that, pull requests cannot be merged directly here.

**But don't worry -- your contribution won't be lost!** Here's what happens next:

1. Our team reviews every PR that comes in.
2. If the change looks good, we'll recreate it internally in our monorepo.
3. The fix will be synced back to this public repo on the next release.

We'll keep you posted on the PR as things progress.

### Is this a bug report?

If you're reporting a bug rather than submitting a code fix, opening an **issue** is usually the fastest path to a resolution. Bug report issues help us triage and prioritize effectively.

Thanks again for helping make OpenSea better for everyone!

## Summary

Fixes `cancelOrders()` rejecting a batch when its orders use differently-cased forms of the same Seaport protocol address.

## Root cause

`cancelOrders()` validates each protocol address with `requireValidProtocol()`, which treats equivalent Ethereum address casing correctly, but then stores the original strings directly in a `Set`.

As a result, the same protocol address in lowercase/checksummed and uppercase form produced two entries, causing the batch to fail with:

`All orders in a cancelOrders batch must share the same protocolAddress.`

even though both orders refer to the same contract.

## Changes

- Normalize validated protocol addresses with `checksumAddress()` before adding them to the batch protocol set.
- Preserve the existing rejection for genuinely different protocol addresses.
- Add a regression test using differently-cased forms of the same Seaport address.

## Validation

- Regression test fails before the fix because the two casing variants are treated as different protocols.
- Targeted regression test: 1/1 passed after the fix.
- Full unit suite: 946/946 passed across 42 test files.
- Targeted Biome check passes for the changed files.