### PR TITLE
fix: infer EIP-712 primaryType in viem adapter

### DIFF
--- a/src/provider/viem-adapter.ts
+++ b/src/provider/viem-adapter.ts
@@ -29,6 +29,23 @@ export interface ViemAdapterParams {
   rpcUrl?: string
 }
 
+/** Infer the EIP-712 root struct: the named type no other struct references. */
+function inferPrimaryType(types: Record<string, Array<{ type: string }>>): string {
+  const namedTypes = Object.keys(types).filter(key => key !== "EIP712Domain")
+  const referencedTypes = new Set<string>()
+
+  for (const fields of Object.values(types)) {
+    for (const field of fields) {
+      const referencedType = field.type.replace(/\[[^\]]*\]$/g, "")
+      if (namedTypes.includes(referencedType)) {
+        referencedTypes.add(referencedType)
+      }
+    }
+  }
+
+  return namedTypes.find(type => !referencedTypes.has(type)) ?? namedTypes[0] ?? ""
+}
+
 /**
  * Creates an OpenSeaWallet from viem clients.
  */
@@ -95,9 +112,7 @@ function createViemSigner(
           verifyingContract: domain.verifyingContract as `0x${string}`,
         },
         types,
-        primaryType:
-          Object.keys(types).find(key => key !== "EIP712Domain") ||
-          Object.keys(types)[0],
+        primaryType: inferPrimaryType(types),
         message: value,
         account: walletClient.account,
       })

--- a/test/provider/viem-adapter.spec.ts
+++ b/test/provider/viem-adapter.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from "vitest"
+import { createViemWallet } from "../../src/provider/viem-adapter"
+
+describe("createViemWallet", () => {
+  test("infers the EIP-712 root primaryType instead of using the first type key", async () => {
+    const signTypedData = vi.fn().mockResolvedValue("0xsignature")
+    const walletClient = {
+      account: { address: "0x0000000000000000000000000000000000000001" },
+      chain: { id: 1 },
+      signTypedData,
+    }
+    const publicClient = {
+      waitForTransactionReceipt: vi.fn(),
+    }
+
+    const wallet = createViemWallet({
+      publicClient: publicClient as never,
+      walletClient: walletClient as never,
+    })
+    if (!("signer" in wallet)) {
+      throw new Error("expected signer")
+    }
+
+    const types = {
+      Person: [{ name: "wallet", type: "address" }],
+      Mail: [
+        { name: "from", type: "Person" },
+        { name: "contents", type: "string" },
+      ],
+    }
+
+    await wallet.signer.signTypedData(
+      {
+        name: "Example",
+        version: "1",
+        chainId: 1,
+        verifyingContract: "0x0000000000000000000000000000000000000002",
+      },
+      types,
+      {
+        from: { wallet: walletClient.account.address },
+        contents: "hello",
+      },
+    )
+
+    expect(signTypedData).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryType: "Mail" }),
+    )
+  })
+})


### PR DESCRIPTION
## Thanks for opening a PR!

We really appreciate you taking the time to contribute. It means a lot to the OpenSea team and the broader developer community.

### A quick note about how this repo works

This repository is a **read-only mirror** of a package maintained in an internal monorepo. Because of that, pull requests cannot be merged directly here.

**But don't worry -- your contribution won't be lost!** Here's what happens next:

1. Our team reviews every PR that comes in.
2. If the change looks good, we'll recreate it internally in our monorepo.
3. The fix will be synced back to this public repo on the next release.

We'll keep you posted on the PR as things progress.

### Is this a bug report?

If you're reporting a bug rather than submitting a code fix, opening an **issue** is usually the fastest path to a resolution. Bug report issues help us triage and prioritize effectively.

Thanks again for helping make OpenSea better for everyone!

## Summary

Fixes EIP-712 signing through the SDK's standard viem wallet adapter when a dependency struct appears before the actual root struct in the `types` object.

This is the same primary-type inference issue addressed for the separate Seaport bridge path in #1998, but `src/provider/viem-adapter.ts` has its own `signTypedData()` implementation and retained the same first-key heuristic.

## Root cause

`createViemSigner().signTypedData()` selected the first non-`EIP712Domain` key as `primaryType`.

EIP-712 does not require the root struct to be declared first. For example, when `Person` is declared before `Mail` and `Mail` references `Person`, the correct primary type is `Mail`, but the viem adapter selected `Person`.

## Changes

- Infer the root EIP-712 struct by finding the named type that is not referenced by another struct.
- Handle struct references through array types such as `Person[]`.
- Preserve the existing first-type fallback for cyclic or ambiguous type graphs.
- Add a regression test specifically against the standard viem wallet adapter path.

## Validation

- Regression test fails before the fix because `Person` is selected instead of `Mail`.
- Targeted regression test: 1/1 passed after the fix.
- Full unit suite: 946/946 passed across 42 test files.
- Targeted Biome check passes for the changed files.

## Related

#1998 fixes the separate Seaport bridge implementation. This PR covers the standard viem adapter implementation in `src/provider/viem-adapter.ts`.