### PR TITLE
fix(wallet-auth): preserve signed upload form field names

### DIFF
--- a/src/api/walletAuth.ts
+++ b/src/api/walletAuth.ts
@@ -232,6 +232,8 @@ export class WalletAuthAPI {
       "POST",
       `/api/v2/drops/${segment(slug)}/items/media`,
       body,
+      undefined,
+      { camelizeResponse: false },
     )
   }
 
@@ -250,6 +252,9 @@ export class WalletAuthAPI {
     return this.fetcher.request<OperationResponse<"upload_drop_allowlist">>(
       "POST",
       `/api/v2/drops/${segment(slug)}/allowlist`,
+      undefined,
+      undefined,
+      { camelizeResponse: false },
     )
   }
 
@@ -301,6 +306,9 @@ export class WalletAuthAPI {
     return this.fetcher.request<OperationResponse<"upload_collection_image">>(
       "POST",
       `/api/v2/collections/${segment(slug)}/images/${segment(imageType)}?${query}`,
+      undefined,
+      undefined,
+      { camelizeResponse: false },
     )
   }
 
@@ -340,7 +348,7 @@ export class WalletAuthAPI {
       "/api/v2/profile/images",
       body,
       undefined,
-      { snakeizeBody: false },
+      { snakeizeBody: false, camelizeResponse: false },
     )
   }
 

--- a/test/api/walletAuthUploadContext.spec.ts
+++ b/test/api/walletAuthUploadContext.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { OpenSeaAPI } from "../../src/api/api"
+import type { WalletAuthFetcher } from "../../src/api/fetcher"
+import { WalletAuthAPI, type WalletAuthRequest } from "../../src/api/walletAuth"
+
+const uploadContext = {
+  url: "https://uploads.example.com/",
+  method: "POST",
+  fields: {
+    key: "uploads/example.png",
+    "Content-Type": "image/png",
+    success_action_status: "201",
+  },
+  token: "upload-token-example",
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("wallet-auth upload context response casing", () => {
+  it("preserves signed multipart field names through the real fetch boundary", async () => {
+    const responses = [uploadContext, [uploadContext]]
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(responses.shift()), { status: 200 }),
+      ),
+    )
+    const api = new OpenSeaAPI({ apiKey: "key", authToken: "jwt" })
+
+    const profile = await api.walletAuth.createProfileImageUpload({
+      imageType: "PROFILE",
+      contentType: "image/png",
+    })
+    const dropMedia = await api.walletAuth.createDropItemMediaUpload("drop", {
+      filenames: [],
+    })
+
+    expect(profile.fields).toEqual(uploadContext.fields)
+    expect(dropMedia[0].fields).toEqual(uploadContext.fields)
+  })
+
+  it("opts every UploadContext helper out of response camelization", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    const api = new WalletAuthAPI({
+      get: vi.fn(),
+      request,
+    } as unknown as WalletAuthFetcher)
+    const dropMediaBody: WalletAuthRequest<"upload_drop_item_media"> = {
+      filenames: [],
+    }
+    const profileImageBody: WalletAuthRequest<"upload_profile_image"> = {
+      imageType: "PROFILE",
+      contentType: "image/png",
+    }
+    const calls = [
+      () => api.createDropItemMediaUpload("drop", dropMediaBody),
+      () => api.createDropAllowlistUpload("drop"),
+      () =>
+        api.createCollectionImageUpload("collection", "banner", "image/png"),
+      () => api.createProfileImageUpload(profileImageBody),
+    ]
+
+    for (const call of calls) {
+      request.mockClear()
+      await call()
+      expect(request.mock.calls[0]?.[4]).toMatchObject({
+        camelizeResponse: false,
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Motivation

Closes #2001

`UploadContext.fields` is an opaque signed multipart field map. Its generated schema explicitly tells callers to submit every entry unchanged, but wallet-auth responses are camelized by default. That rewrites valid field names such as `success_action_status` to `successActionStatus`, so the SDK can return a different upload context from the one supplied by the API.

All four wallet-auth helpers that return an `UploadContext` are affected: drop item media, drop allowlist, collection image, and profile image uploads.

## Solution

Disable response camelization only for those four upload-context helpers. Other wallet-auth responses keep their existing camelCase behavior, and the profile image request keeps its existing `snakeizeBody: false` behavior.

The regression coverage verifies both response shapes used by the API:

- a single upload context through the real fetch boundary
- an array of upload contexts through the real fetch boundary
- all four helper call sites opt out of response camelization

Validation:

- `npm run build`
- `npm run check-types`
- `npm run lint` (passes with the existing unrelated `Function` warning)
- `npm test` (48 files, 1009 tests)
