### PR TITLE
docs: fix instant API key response casing in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Get started by getting an API key and instantiating your own OpenSea SDK instanc
 ```typescript
 import { OpenSeaSDK } from "@opensea/sdk";
 
-const { api_key } = await OpenSeaSDK.requestInstantApiKey();
-const sdk = new OpenSeaSDK(provider, { chain: Chain.Mainnet, apiKey: api_key });
+const { apiKey } = await OpenSeaSDK.requestInstantApiKey();
+const sdk = new OpenSeaSDK(provider, { chain: Chain.Mainnet, apiKey });
 ```
 
 Or from the shell:

--- a/developerDocs/quick-start.md
+++ b/developerDocs/quick-start.md
@@ -40,7 +40,7 @@ To get started, first get an API key.
 ```typescript
 import { OpenSeaSDK } from "@opensea/sdk";
 
-const { api_key } = await OpenSeaSDK.requestInstantApiKey();
+const { apiKey } = await OpenSeaSDK.requestInstantApiKey();
 ```
 
 Or from the shell:


### PR DESCRIPTION
## Summary

- use `apiKey` when destructuring `OpenSeaSDK.requestInstantApiKey()` in the README and quick-start guide
- keep `.api_key` unchanged in the raw `curl` examples

## Why

The SDK camelizes the endpoint response and its return type exposes `apiKey`. The current TypeScript examples use the wire-format `api_key`, which fails with `TS2339` and leaves the constructor without the returned key.

## Validation

- reproduced the current example as a standalone TypeScript consumer: `Property api_key does not exist`
- verified the `apiKey` version type-checks against the built declarations
- `npm run format:check -- README.md developerDocs/quick-start.md`
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test` (49 files, 1016 tests)